### PR TITLE
Add event listener for updates on contact entities for creating change records

### DIFF
--- a/Civi/Share/EventSubscriber/ContactChangeSubscriber.php
+++ b/Civi/Share/EventSubscriber/ContactChangeSubscriber.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Civi\Share\EventSubscriber;
+
+use api\v4\Custom\FalseNotEqualsZeroTest;
+use Civi\Api4\Contact;
+use Civi\Api4\ShareChange;
+use Civi\Api4\ShareNode;
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\Service\AutoSubscriber;
+use Civi\Share\Utils;
+
+class ContactChangeSubscriber extends AutoSubscriber {
+
+  /**
+   * @inheritDoc
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      'hook_civicrm_pre' => 'preContact',
+      'hook_civicrm_post' => 'postContact',
+    ];
+  }
+
+  public function preContact(GenericHookEvent $event): void {
+    /**
+     * @var string $op
+     * @var string $objectName
+     * @var int|null $id
+     * @var array $params
+     */
+    [$op, $objectName, $id, &$params] = $event->getHookValues();
+    // TODO: Handle other operations.
+    if ('edit' === $op && \Civi\Api4\Utils\CoreUtil::isContact($event->entity)) {
+      // TODO: This does not include "custom_" fields submitted in $params - and is generally not comparing compatible
+      //       data structures. Which keys can $params contain in the first place?
+      $fields = Contact::getFields(FALSE)
+        ->addSelect('name')
+        ->execute()
+        ->column('name');
+      $submittedFields = array_intersect_key($params, array_flip($fields));
+
+      $currentContact = Contact::get(FALSE)
+        ->addSelect(...array_keys($submittedFields))
+        ->addWhere('id', '=', $id)
+        ->execute()
+        ->single();
+
+      foreach (array_diff($submittedFields, $currentContact) as $fieldName => $change) {
+        \Civi::$statics[__CLASS__]['changes'][$id]['before'][$fieldName] = $currentContact[$fieldName] ?? NULL;
+      }
+    }
+  }
+
+  public function postContact(GenericHookEvent $event): void {
+    /**
+     * @var string $op
+     * @var string $objectName
+     * @var int $objectId
+     * @var \CRM_Contact_BAO_Contact $objectRef
+     */
+    [$op, $objectName, $objectId, &$objectRef] = $event->getHookValues();
+    // TODO: Handle other operations.
+    if ('edit' === $op && \Civi\Api4\Utils\CoreUtil::isContact($event->entity)) {
+      $dataBefore = \Civi::$statics[__CLASS__]['changes'][$objectId]['before'] ?? [];
+      if ([] !== $dataBefore) {
+        $dataAfter = Contact::get(FALSE)
+          ->addSelect(...array_keys(\Civi::$statics[__CLASS__]['changes'][$objectId]['before']))
+          ->addWhere('id', '=', $objectId)
+          ->execute()
+          ->single();
+
+        // TODO: How to determine the default local node?
+        $localNodeId = ShareNode::get(FALSE)
+          ->addSelect('id')
+          ->addWhere('is_local', '=', TRUE)
+          ->addWhere('is_enabled', '=', TRUE)
+          ->execute()
+          ->first()['id'];
+
+        $change = ShareChange::create()
+          ->addValue('change_type', 'civishare.change.contact.base')
+          ->addValue('change_date', (new \DateTime())->format(Utils::CIVICRM_DATE_FORMAT))
+          ->addValue('status', \Civi\Share\Change::STATUS_LOCAL)
+          ->addValue('local_contact_id', $objectId)
+          ->addValue('source_node_id', $localNodeId)
+          ->addValue('data_before', $dataBefore)
+          ->addValue('data_after', array_intersect_key($dataAfter, $dataBefore))
+          ->execute();
+      }
+      unset(\Civi::$statics[__CLASS__]['changes'][$objectId]);
+    }
+  }
+
+}


### PR DESCRIPTION
POC target of this:
* record changes to existing contacts for typical attributes (e.g. not necessarily custom fields or attached entities)
* record new contacts
* store *ShareChange* entities for a default local *ShareNode*

TODO:
* How to identify the default local *ShareNode* (as there might be multiple)
* ~~record creation of contacts~~

*systopia-reference: 27549*