### PR TITLE
Dispatch event for determining target node peerings per change

### DIFF
--- a/Civi/Share/Api4/Action/ShareChangeMessage/SendAction.php
+++ b/Civi/Share/Api4/Action/ShareChangeMessage/SendAction.php
@@ -32,10 +32,12 @@ class SendAction extends AbstractAction {
    * @inheritDoc
    */
   public function _run(Result $result): void {
-    $message = Message::createForSourceNode($this->sourceNodeId);
-    $message->setSenderNodeId($this->sourceNodeId);
-    $sendResult = $message->send($this->sourceNodeId);
-    $result->exchangeArray($sendResult);
+    $sendResults = [];
+    foreach (Message::generateForSourceNode($this->sourceNodeId) as $message) {
+      $message->setSenderNodeId($this->sourceNodeId);
+      $sendResults[] = $message->send();
+    }
+    $result->exchangeArray($sendResults);
   }
 
 }

--- a/Civi/Share/Change.php
+++ b/Civi/Share/Change.php
@@ -159,7 +159,7 @@ class Change {
       $shareChange['source_node_id'],
       self::parseAttributeChanges($shareChange['data_before'] ?? [], $shareChange['data_after'] ?? []),
       \DateTime::createFromFormat(Utils::CIVICRM_DATE_FORMAT, $shareChange['change_date']),
-      \DateTime::createFromFormat(Utils::CIVICRM_DATE_FORMAT, $shareChange['received_date']),
+      isset($shareChange['received_date']) ? \DateTime::createFromFormat(Utils::CIVICRM_DATE_FORMAT, $shareChange['received_date']) : NULL,
       $shareChange['status'],
       $shareChange['id']
     );

--- a/Civi/Share/CiviMRF/ShareApi.php
+++ b/Civi/Share/CiviMRF/ShareApi.php
@@ -4,6 +4,7 @@ namespace Civi\Share\CiviMRF;
 
 use Civi\Core\Service\AutoServiceInterface;
 use Civi\Core\Service\AutoServiceTrait;
+use Civi\Share\Message;
 
 /**
  * @service civi.share.api
@@ -18,11 +19,11 @@ class ShareApi implements AutoServiceInterface {
    */
   protected $civiMRFClient;
 
-  public function sendMessage(string $shareNodePeeringId, array $message): array {
+  public function sendMessage(string $shareNodePeeringId, Message $message): array {
     return $this->civiMRFClient
       ->init($shareNodePeeringId)
       ->executeV4('ShareChangeMessage', 'receive', [
-      'message' => $message,
+      'message' => $message->serialize(),
     ]);
   }
 

--- a/Civi/Share/Event/TargetNodePeeringDetermineEvent.php
+++ b/Civi/Share/Event/TargetNodePeeringDetermineEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Civi\Share\Event;
+
+use Civi\Share\Change;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class TargetNodePeeringDetermineEvent extends Event {
+
+  private Change $change;
+
+  /**
+   * @phpstan-var list<int>
+   */
+  public array $targetNodePeeringIds = [];
+
+  public function __construct(Change $change, array $targetNodePeeringIds = []) {
+    $this->change = $change;
+    $this->targetNodePeeringIds = $targetNodePeeringIds;
+  }
+
+  public function getChange() {
+    return $this->change;
+  }
+
+  public function getTargetNodePeeringIds() {
+    return $this->targetNodePeeringIds;
+  }
+
+}

--- a/Civi/Share/Event/TargetNodePeeringDetermineEvent.php
+++ b/Civi/Share/Event/TargetNodePeeringDetermineEvent.php
@@ -2,6 +2,7 @@
 
 namespace Civi\Share\Event;
 
+use Civi\Api4\ShareNodePeering;
 use Civi\Share\Change;
 use Symfony\Contracts\EventDispatcher\Event;
 
@@ -25,6 +26,15 @@ class TargetNodePeeringDetermineEvent extends Event {
 
   public function getTargetNodePeeringIds() {
     return $this->targetNodePeeringIds;
+  }
+
+  public function getEligibleTargetNodePeeringIds() {
+    return ShareNodePeering::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('id', 'IN', $this->targetNodePeeringIds)
+      ->addWhere('is_enabled', '=', TRUE)
+      ->execute()
+      ->column('id');
   }
 
 }

--- a/Civi/Share/Message.php
+++ b/Civi/Share/Message.php
@@ -98,7 +98,7 @@ class Message
       // Determine target node peerings to send this message to depending on the change.
       $targetNodePeeringResolveEvent = new TargetNodePeeringDetermineEvent($change);
       $message->eventDispatcher->dispatch($targetNodePeeringResolveEvent);
-      $message->targetNodePeeringIds = $targetNodePeeringResolveEvent->getTargetNodePeeringIds();
+      $message->targetNodePeeringIds = $targetNodePeeringResolveEvent->getEligibleTargetNodePeeringIds();
       $message->setSenderNodeId($sourceNodeId);
 
       // TODO: As this currently creates one message per change record, this should be optimized by e. g. combining

--- a/api/v3/CiviShareTests/Test01.php
+++ b/api/v3/CiviShareTests/Test01.php
@@ -96,7 +96,8 @@ function civicrm_api3_civi_share_tests_test01(&$params) {
   $change_message->processChanges($local_node['id']);
 
   // send
-  $change_message->send();
+  $change_message->setShareApi(Civi::service('civi.share.mock.api'));
+  $change_message->sendToAll();
 
   // this should now be processed
   if (!$change_message->allChangesProcessed()) {

--- a/api/v3/CiviShareTests/Test02.php
+++ b/api/v3/CiviShareTests/Test02.php
@@ -126,7 +126,8 @@ function civicrm_api3_civi_share_tests_test02(&$params) {
   $change_message->processChanges($local_node['id']);
 
   // send
-  $change_message->send();
+  $change_message->setShareApi(Civi::service('civi.share.mock.api'));
+  $change_message->sendToAll();
 
   // this should now be processed
   if (!$change_message->allChangesProcessed()) {

--- a/api/v3/CiviShareTests/Test03.php
+++ b/api/v3/CiviShareTests/Test03.php
@@ -100,7 +100,8 @@ function civicrm_api3_civi_share_tests_test03(&$params) {
   $change_message = new Message();
   $change_message->addChangeById($change_id);
   $change_message->processChanges($local_node['id']);
-  $change_message->send();
+  $change_message->setShareApi(Civi::service('civi.share.mock.api'));
+  $change_message->sendToAll();
 
   // this should now be processed
   if (!$change_message->allChangesProcessed()) {

--- a/api/v3/CiviShareTests/Test04.php
+++ b/api/v3/CiviShareTests/Test04.php
@@ -154,7 +154,8 @@ function civicrm_api3_civi_share_tests_test04(&$params) {
   $change_message = new Message();
   $change_message->addChangeById($change_id);
   $change_message->processChanges($local_node['id']);
-  $change_message->send();
+  $change_message->setShareApi(Civi::service('civi.share.mock.api'));
+  $change_message->sendToAll();
 
   // this should now be processed
   if (!$change_message->allChangesProcessed()) {

--- a/tests/phpunit/Civi/Share/Mock/CiviMRF/ShareApi.php
+++ b/tests/phpunit/Civi/Share/Mock/CiviMRF/ShareApi.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace tests\phpunit\Civi\Share\Mock\CiviMRF;
+
+use Civi\Api4\ShareNodePeering;
+use Civi\Share\Message;
+
+/**
+ * @service civi.share.mock.api
+ *
+ * Mock service for the CiviShare CiviMRF API which uses a local-to-local shortcut if the node peering does not include
+ * remote information.
+ */
+class ShareApi extends \Civi\Share\CiviMRF\ShareApi {
+
+  public function sendMessage(string $shareNodePeeringId, Message $message): array {
+    $peering = ShareNodePeering::get(FALSE)
+      ->addSelect('id', 'remote_node', 'remote_node.*')
+      ->addWhere('id', '=', $shareNodePeeringId)
+      ->execute();
+    if (empty($peering['remote_node.rest_url']) || empty($peering['remote_node.api_key'])) {
+      if (defined('CIVISHARE_ALLOW_LOCAL_LOOP')) {
+        $message->processOnNode($peering['remote_node.id']);
+      }
+    }
+    else {
+      return parent::sendMessage($shareNodePeeringId, $message);
+    }
+  }
+
+}


### PR DESCRIPTION
This refactors sending change messages:
* do not send to all peered nodes for a given local node
* (for now, to be optimized) generate one change message per change
* dispatch an event for determining target node peerings per change message

This also adds a mock service for a local-to-local workaround in tests and adjusts them so that they still send to all connected remote nodes of a given local node. Those API3-driven "tests" should be migrated to real tests though.

TODO:
* defaults to no target node peerings, so adding a configurable listener with a switch for sending to all active peered nodes (legacy default behavior)
* utilizing a queue for scalability